### PR TITLE
Error modifying hash in ruby-1.9.2

### DIFF
--- a/Ruby/lib/directed_edge.rb
+++ b/Ruby/lib/directed_edge.rb
@@ -114,7 +114,7 @@ module DirectedEdge
     # :foo_bar to 'fooBar'
 
     def normalize_params!(hash)
-      hash.each do |key, value|
+      hash.clone.each do |key, value|
         if !key.is_a?(String)
           hash.delete(key)
           key = key.to_s


### PR DESCRIPTION
```
When weshop sends out the daily deals                 # features/step_definitions/daily_targeted_deal_steps.rb:3
      can't add a new key into hash during iteration (RuntimeError)
      /Users/karl/ws/weshop-directed-edge-bindings/Ruby/lib/directed_edge.rb:121:in `store'
      /Users/karl/ws/weshop-directed-edge-bindings/Ruby/lib/directed_edge.rb:121:in `block in normalize_params!'
      /Users/karl/ws/weshop-directed-edge-bindings/Ruby/lib/directed_edge.rb:117:in `each'
      /Users/karl/ws/weshop-directed-edge-bindings/Ruby/lib/directed_edge.rb:117:in `normalize_params!'
      /Users/karl/ws/weshop-directed-edge-bindings/Ruby/lib/directed_edge.rb:753:in `recommended'
```
